### PR TITLE
Tidy macros

### DIFF
--- a/database_normalization/database_normalization.md
+++ b/database_normalization/database_normalization.md
@@ -52,8 +52,7 @@ repo_link: [GitHub repository for these materials](https://github.com/arcus/arcu
 module_link: [an online self-paced tutorial](https://bit.ly/DART_database_normalization)
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
-
-
+import: https://raw.githubusercontent.com/arcus/arcus_skill_series_sql/main/macros_slides.md
 import: https://raw.githubusercontent.com/LiaTemplates/mermaid_template/0.1.4/README.md
 -->
 

--- a/database_normalization/database_normalization.md
+++ b/database_normalization/database_normalization.md
@@ -49,7 +49,7 @@ No previous versions.
 
 
 repo_link: [GitHub repository for these materials](https://github.com/arcus/arcus_skill_series_sql)
-module_link: [an online self-paced tutorial](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/database_normalization/database_normalization.md)
+module_link: [an online self-paced tutorial](https://bit.ly/DART_database_normalization)
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
 

--- a/database_normalization/database_normalization.md
+++ b/database_normalization/database_normalization.md
@@ -53,66 +53,8 @@ module_link: [an online self-paced tutorial](https://bit.ly/DART_database_normal
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
 
-big: <b style="font-size: 1.25em;">@0</b>
-center: <div style="text-align: center;">@0</div>
-colorhighlight: <b style="font-size: 1.15em; color: rgba(var(--color-highlight));">@0</b>
 
-@sql_series_slide
-
-<div style = "text-align: center; font-weight: bold;font-size: 1.5em; color: white; background-color: rgba(var(--color-highlight));">Welcome to the Arcus Education Skill Series!</div>
-
-<br>
-
-<div style = "align-items: center; display: flex;">
-<div style = "margin: 1rem; max-width: 30%; float:left; padding-right:4em;">![""](../media/SQL-Logo.png)
-</div>
-<div style = "margin: 1rem auto; max-width: 65%; float:left;">
-<h3>Beyond the Spreadsheet: Understanding SQL and Relational Databases</h3> 
-
-</div>
-</div>
-@end
-
-@todays_talk
-@big(@title)
-
-@learning_objectives
-@end
-
-@about_these_slides
-
-These slides were created with [LiaScript](https://liascript.github.io/), an open source markdown parser for writing educational content.
-
-All of the speaker notes from today's talk are saved in [the slides themselves](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/arcus_skill_series_sql/main/database_normalization/database_normalization.md#1) -- try changing the view to Textbook and it will integrate the text from the notes into the slides themselves, or turn on the sound at the bottom to hear the notes read out loud as you go through. 
-
-<div style = "align-items: center; display: flex;">
-<div style = "margin-left: 10%; max-width: 25%; float:left; border-style: solid; border-color: rgba(var(--color-highlight));">
-![Screenshot showing the upper right menus on a liascript page with the mode menu open and Textbook highlighted.](../media/liascript_mode.png)
-</div>
-<div style = "margin-right: 10%; max-width: 25%; float:right; border-style: solid; border-color: rgba(var(--color-highlight));">
-![Screenshot showing the sound buttons at the bottom of a liascript page with the speaker button highlighted.](../media/liascript_sound.png)
-</div>
-</div>
-
-The content from this talk is also available as @module_link 
-
-For all of the files and information from this talk, go to our @repo_link 
-
-@end
-
-@teams_polls 
-
-@big(Today's presentation will include interactive content!)
-
-The best way to learn is to practice!
-
-When we reach 💫 **Your Turn** sections, test your knowledge and respond in the Teams poll or the chat section.
-Then we'll discuss the answer together.
-
-@end
 import: https://raw.githubusercontent.com/LiaTemplates/mermaid_template/0.1.4/README.md
-
-
 -->
 
 # Database Normalization

--- a/demystifying_sql/demystifying_sql.md
+++ b/demystifying_sql/demystifying_sql.md
@@ -51,7 +51,7 @@ repo_link: [GitHub repository for these materials](https://github.com/arcus/arcu
 module_link: [an online self-paced tutorial](https://bit.ly/DART_demystifying_sql)
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
-
+import: https://raw.githubusercontent.com/arcus/arcus_skill_series_sql/main/macros_slides.md
 -->
 
 # Demystifying SQL

--- a/demystifying_sql/demystifying_sql.md
+++ b/demystifying_sql/demystifying_sql.md
@@ -22,6 +22,8 @@ Experience working with rectangular data (data in rows and columns) will be help
 @end
 
 @learning_objectives  
+After completion of this module, learners will be able to:
+
 - Define the acronym "SQL"
 - Explain the basic organization of data in relational databases
 - Explain what "relational" means in the phrase "relational database"
@@ -50,65 +52,6 @@ module_link: [an online self-paced tutorial](https://bit.ly/DART_demystifying_sq
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
 
-big: <b style="font-size: 1.25em;">@0</b>
-center: <div style="text-align: center;">@0</div>
-colorhighlight: <b style="font-size: 1.15em; color: rgba(var(--color-highlight));">@0</b>
-
-@sql_series_slide
-
-<div style = "text-align: center; font-weight: bold;font-size: 1.5em; color: white; background-color: rgba(var(--color-highlight));">Welcome to the Arcus Education Skill Series!</div>
-
-<br>
-
-<div style = "align-items: center; display: flex;">
-<div style = "margin: 1rem; max-width: 30%; float:left; padding-right:4em;">![""](../media/SQL-Logo.png)
-</div>
-<div style = "margin: 1rem auto; max-width: 65%; float:left;">
-<h3>Beyond the Spreadsheet: Understanding SQL and Relational Databases</h3> 
-
-</div>
-</div>
-@end
-
-@todays_talk
-@big(@title)
-
-After this session, learners will be able to:
-
-@learning_objectives
-@end
-
-@about_these_slides
-
-These slides were created with [LiaScript](https://liascript.github.io/), an open source markdown parser for writing educational content.
-
-All of the speaker notes from today's talk are saved in the slides themselves -- try changing the view to Textbook and it will integrate the text from the notes into the slides themselves, or turn on the sound at the bottom to hear the notes read out loud as you go through. 
-
-<div style = "align-items: center; display: flex;">
-<div style = "margin-left: 10%; max-width: 25%; float:left; border-style: solid; border-color: rgba(var(--color-highlight));">
-![Screenshot showing the upper right menus on a liascript page with the mode menu open and Textbook highlighted.](../media/liascript_mode.png)
-</div>
-<div style = "margin-right: 10%; max-width: 25%; float:right; border-style: solid; border-color: rgba(var(--color-highlight));">
-![Screenshot showing the sound buttons at the bottom of a liascript page with the speaker button highlighted.](../media/liascript_sound.png)
-</div>
-</div>
-
-The content from this talk is also available as @module_link 
-
-For all of the files and information from this talk, go to our @repo_link 
-
-@end
-
-@teams_polls 
-
-@big(Today's presentation will include interactive content!)
-
-The best way to learn is to practice!
-
-When we reach 💫 **Your Turn** sections, test your knowledge and respond in the Teams poll. 
-Then we'll discuss the answer together.
-
-@end
 -->
 
 # Demystifying SQL

--- a/macros_slides.md
+++ b/macros_slides.md
@@ -13,40 +13,6 @@ comment:  This is placeholder module to save macros used in when creating slide 
 No previous versions.
 @end
 
-@sql_series_slide
-
-**Welcome to the Arcus Education Skill Series!**
-
-<br>
-
-<div style = "align-items: center; display: flex;">
-<div style = "margin: 1rem; max-width: 30%; float:left; padding-right:4em;">![""](../media/SQL-Logo.png)
-</div>
-<div style = "margin: 1rem auto; max-width: 65%; float:left;">
-<h3>Beyond the Spreadsheet: Understanding SQL and Relational Databases</h3> 
-
-</div>
-</div>
-@end
-
-@todays_talk
-<h3>@title</h3>
-
-After this session, learners will be able to:
-
-@learning_objectives
-@end
-
-@about_these_slides
-
-Today's presentation will include interactive content!
-
-To participate, open our [classroom link](@classroom_link).
-Don't edit the room name, just click "connect". 
-
-You'll be able to step through the slides yourself to follow along, and when we get to **Your Turn** sections, you can enter your response on your screen to anonymously share with the group.
-
-@end
 
 -->
 # Macros for slides

--- a/macros_slides.md
+++ b/macros_slides.md
@@ -13,7 +13,65 @@ comment:  This is placeholder module to save macros used in when creating slide 
 No previous versions.
 @end
 
+@onload: window.LIA.settings.sound = false
 
+big: <b style="font-size: 1.25em;">@0</b>
+center: <div style="text-align: center;">@0</div>
+colorhighlight: <b style="font-size: 1.15em; color: rgba(var(--color-highlight));">@0</b>
+
+@sql_series_slide
+
+<div style = "text-align: center; font-weight: bold;font-size: 1.5em; color: white; background-color: rgba(var(--color-highlight));">Welcome to the Arcus Education Skill Series!</div>
+
+<br>
+
+<div style = "align-items: center; display: flex;">
+<div style = "margin: 1rem; max-width: 30%; float:left; padding-right:4em;">![""](../media/SQL-Logo.png)
+</div>
+<div style = "margin: 1rem auto; max-width: 65%; float:left;">
+<h3>Beyond the Spreadsheet: Understanding SQL and Relational Databases</h3> 
+
+</div>
+</div>
+@end
+
+@todays_talk
+@big(@title)
+
+@learning_objectives
+@end
+
+@about_these_slides
+
+These slides were created with [LiaScript](https://liascript.github.io/), an open source markdown parser for writing educational content.
+
+All of the speaker notes from today's talk are saved in [the slides themselves](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/arcus_skill_series_sql/main/database_normalization/database_normalization.md#1) -- try changing the view to Textbook and it will integrate the text from the notes into the slides themselves, or turn on the sound at the bottom to hear the notes read out loud as you go through. 
+
+<div style = "align-items: center; display: flex;">
+<div style = "margin-left: 10%; max-width: 25%; float:left; border-style: solid; border-color: rgba(var(--color-highlight));">
+![Screenshot showing the upper right menus on a liascript page with the mode menu open and Textbook highlighted.](../media/liascript_mode.png)
+</div>
+<div style = "margin-right: 10%; max-width: 25%; float:right; border-style: solid; border-color: rgba(var(--color-highlight));">
+![Screenshot showing the sound buttons at the bottom of a liascript page with the speaker button highlighted.](../media/liascript_sound.png)
+</div>
+</div>
+
+The content from this talk is also available as @module_link 
+
+For all of the files and information from this talk, go to our @repo_link 
+
+@end
+
+@teams_polls 
+
+@big(Today's presentation will include interactive content!)
+
+The best way to learn is to practice!
+
+When we reach 💫 **Your Turn** sections, test your knowledge and respond in the Teams poll or the chat section.
+Then we'll discuss the answer together.
+
+@end
 -->
 # Macros for slides
 


### PR DESCRIPTION
This removes the macros defined in the front matter for our slides md files and instead saves them in the macros_slides.md file which is then imported (just like we do for the education_modules repo). 